### PR TITLE
Point to the right build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Build Status
 ============
-- Master Branch: [![Build Status](https://travis-ci.org/pharo-project/pharo-vm.png?branch=master)](https://travis-ci.org/pharo-project/pharo-vm)
-- Develop Branch: [![Build Status](https://travis-ci.org/pharo-project/pharo-vm.png?branch=develop)](https://travis-ci.org/pharo-project/pharo-vm)
+- Spur64 Branch: [![Build Status](https://travis-ci.org/estebanlm/pharo-vm.png?branch=spur64)](https://travis-ci.org/estebanlm/pharo-vm)
 
 REQUIREMENTS
 ============


### PR DESCRIPTION
Do not use the build result of a branch that is currently not being
built. Point to what the build result would be if travis-ci is
configured for that repository.
