### PR TITLE
Update instruction to point to the right build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,21 @@ example VM configurations. In case there is no workspace, open one and paste the
 Pick or edit the configuration you want, then evaluate it (Do It).
  ```Smalltalk
  "Unix"
- PharoVMBuilder buildUnix32.
+ PharoVMSpur32Builder buildUnix32.
  "OSX"
- PharoVMBuilder buildMacOSX32.
+ PharoVMSpur32Builder buildMacOSX32.
  "Windows"
- PharoVMBuilder buildWin32.
+ PharoVMSpur32Builder buildWin32.
  ```
 See `startup.st` for more examples for the common platforms.
 
 As an alternative, try (Windows flavor shown):
 
 ```
-./pharo generator.image eval 'PharoVMBuilder buildWin32'
+./pharo generator.image eval 'PharoVMSpur32Builder buildWin32'
 ```
 
-Should you want to build a StackVM version, use the PharoSVMBuilder.
+Should you want to build a StackVM version, use the PharoSVMSpur32Builder.
 
 4. Once the sources are exported, you can launch cmake and build the VM:
 ```bash

--- a/image/startup.st
+++ b/image/startup.st
@@ -12,21 +12,21 @@ GTPlayground
 		stream 
 			<< '"Configuration for the Pharo VM'; cr;
 			<< ' ------------------------------"'; cr;
-			<< 'PharoVMBuilder buildUnix32.'; cr;
-			<< 'PharoVMBuilder buildMacOSX32.'; cr;
-			<< 'PharoVMBuilder buildWin32.'; cr; 
+			<< 'PharoVMSpur32Builder buildUnix32.'; cr;
+			<< 'PharoVMSpur32Builder buildMacOSX32.'; cr;
+			<< 'PharoVMSpur32Builder buildWin32.'; cr;
 			cr.
 		
 		stream 
 			<< '"Configuration for the PharoS VM'; cr;
 			<< ' -------------------------------"'; cr;
-			<< 'PharoSVMBuilder buildUnix32.'; cr; 
-			<< 'PharoSVMBuilder buildMacOSX32.'; cr;
-			<< 'PharoSVMBuilder buildWin32.'; cr; 
+			<< 'PharoSVMSpur32Builder buildUnix32.'; cr;
+			<< 'PharoSVMSpur32Builder buildMacOSX32.'; cr;
+			<< 'PharoSVMSpur32Builder buildWin32.'; cr;
 			cr.
 
 		stream 
-			<< '"For more details see the internals of PharoVMBuilder and PharoSVMBuilder"'; cr.
+			<< '"For more details see the internals of PharoVMSpur32Builder and PharoSVMSpur32Builder"'; cr.
     ])
 	label: 'Building VM'.
 ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ cd "$SCRIPT_DIR/../image"
 
 echo "
 NonInteractiveTranscript stdout install.
-PharoVMBuilder buildOnJenkins: '$OS'.
+PharoVMSpur32Builder buildOnJenkins: '$OS'.
 " > ./script.st
 
 ./pharo generator.image --quit script.st


### PR DESCRIPTION
PharoVMBuilder is broken and probably deprecated at the same time.
Update to point to the builder used on the CI.
